### PR TITLE
Open link in new tab

### DIFF
--- a/features/chat/components/message.tsx
+++ b/features/chat/components/message.tsx
@@ -28,14 +28,14 @@ export function Message({ message }: { message: Message }) {
         </code>
       );
     },
-    a: ({ node, ...props }) => (
+    a: ({ node, children, ...props }) => (
       <a
         {...props}
         target="_blank"
         rel="noopener noreferrer"
         className="text-blue-500 underline"
       >
-        {props.children}
+        {children}
       </a>
     ),
   };


### PR DESCRIPTION
Currently, when the chat bot provides URLs, these are always opened in the same tab as the chat bot. This behaviour is a bit inconvient because the user has to return to the chat bot to continue asking further questions. I think we should implement the common best practice to open links of external resources in a new tab. 

For this, I extended the used react-markdown implementation for hyperlinks to open these in a new tab by adding corresponding attributes _target="\_blank"_ and _rel="noopener noreferrer_ for the _\<a\>_ tag in HTML.